### PR TITLE
Fixes existing record check

### DIFF
--- a/dyndns53.py
+++ b/dyndns53.py
@@ -73,7 +73,7 @@ def r53_upsert(host, hostconf, ip):
 	)
 
 	old_ip = None
-	if not record_set:
+	if len(record_set['ResourceRecordSets']) < 1:
 		msg = "No existing record found for host {} in zone {}"
 		logger.info(msg.format(host, hostconf['zone_id']))
 	else:


### PR DESCRIPTION
The code mistakenly assumes that `list_resource_record_sets` will return nothing if the record doesn't exist. But it actually returns a normal object with an empty `ResourceRecordSets` array.

This change fixes the check so that it correctly identifies when a record doesn't already exist and stops throwing an error because it's trying to get the old record details.

As a result, you no longer need to pre-create the A record.